### PR TITLE
Fix/content encoding for non octet stream content types

### DIFF
--- a/pyas2lib/as2.py
+++ b/pyas2lib/as2.py
@@ -434,7 +434,7 @@ class Message:
         self.payload.set_payload(data)
         self.payload.set_type(content_type)
 
-        if content_type.lower().startswith("application/octet-stream"):
+        if not content_type.lower().startswith("text/"):
             self.payload["Content-Transfer-Encoding"] = "binary"
         else:
             encoders.encode_7or8bit(self.payload)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 install_requires = [
     "asn1crypto==1.5.1",
@@ -27,7 +27,7 @@ setup(
     long_description="Docs for this project are maintained at "
     "https://github.com/abhishek-ram/pyas2-lib/blob/"
     "master/README.md",
-    version="1.4.4",
+    version="1.4.5",
     author="Abhishek Ram",
     author_email="abhishek8816@gmail.com",
     packages=find_packages(where=".", exclude=("test*",)),


### PR DESCRIPTION

issues with content type have lead to the wrong transfer-content-encoding being used
anything other than application/octet-stream as a content type doesn't have the

         ["Content-Transfer-Encoding"] = "binary"

header

the solution is to

propagate the best-guess mimetype of using the filename to the message build, and
update pyas2-lib to make anything other than "text/.*" content types use the binary content-transfer-encoding