### PR TITLE
Relax pyOpenSSL pin to >=25.0,<27 to allow cryptography 46.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 install_requires = [
     "asn1crypto==1.5.1",
     "oscrypto==1.3.0",
-    "pyOpenSSL==25.0",
+    "pyOpenSSL>=25.0,<27",
 ]
 
 tests_require = [


### PR DESCRIPTION
## Summary
- Relaxes the hard-pinned `pyOpenSSL==25.0` in `setup.py` to `>=25.0,<27`
- pyOpenSSL 25.3+/26.0 supports cryptography 46.x with no breaking changes
- Unblocks bumping `cryptography` to 46.0.6 in `as2-webhook` (CVE-2026-26007)

