### PR TITLE
Feature/update versions for release 1.4.4 (#73)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,5 +1,5 @@
 - Abhishek Ram <abhishek.ram@me.com> @abhishek-ram
-- Chad Gates @chadgates
+- Wassilios Lytras @chadgates
 - Bruno Ribeiro da Silva <bruno.devpod@gmail.com> @loop0
 - Robin C Samuel @robincsamuel
 - Brandon Joyce @brandonjoyce

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Release History
 
+## 1.4.4 - 2024-05-18
+
+* feat: add callback option to find partnerships (organization and partner combinations)
+* fix: add specific error when MDN received but original message was not found
+* feat: add key encryption algorithm parameters to partners with additional support for rsaes_oaep
+* feat: add signature algorithm parameter to partners with additional support for rsassa_pss
+* feat: add message id parameter to allow user provided message id 
+* fix: bump pyOpenSSL version to 23.2.0, which bumps cryptography version to 41.0.x which fixes CVE-2023-2650
+
 ## 1.4.3 - 2023-01-25
 
-* fix: update pyopenssl version to resovle pyca/cryptography#7959
+* fix: update pyopenssl version to resolve pyca/cryptography#7959
 
 ## 1.4.2 - 2022-12-11
 

--- a/pyas2lib/__init__.py
+++ b/pyas2lib/__init__.py
@@ -9,7 +9,7 @@ from pyas2lib.as2 import Message
 from pyas2lib.as2 import Organization
 from pyas2lib.as2 import Partner
 
-__version__ = "1.4.3"
+__version__ = "1.4.4"
 
 
 __all__ = [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 install_requires = [
     "asn1crypto==1.5.1",
     "oscrypto==1.3.0",
-    "pyOpenSSL==23.2.0",
+    "pyOpenSSL>=23.2.0",
 ]
 
 tests_require = [
@@ -27,7 +27,7 @@ setup(
     long_description="Docs for this project are maintained at "
     "https://github.com/abhishek-ram/pyas2-lib/blob/"
     "master/README.md",
-    version="1.4.3",
+    version="1.4.4",
     author="Abhishek Ram",
     author_email="abhishek8816@gmail.com",
     packages=find_packages(where=".", exclude=("test*",)),


### PR DESCRIPTION
Merge of upstream update (1.4.4)

* Update setup.py, allow any version greater than 23.2 for pyopenssl
